### PR TITLE
Collectible Cards

### DIFF
--- a/CardConfig.lua
+++ b/CardConfig.lua
@@ -1,5 +1,7 @@
 ConfigCards = {}
 ConfigCards.Item = "CollectorCard"
+Config.EnableCards = true
+Config.CardTime = 3600 -- = 1 hour, this is time in seconds before card can be collected again, you can also do 60 * 60 for example
 ConfigCards.Cards = {
     {
         name = "Flora Of North America",

--- a/CardConfig.lua
+++ b/CardConfig.lua
@@ -1,5 +1,5 @@
 ConfigCards = {}
-
+ConfigCards.Item = "CollectorCard"
 ConfigCards.Cards = {
     {
         name = "Flora Of North America",

--- a/CardConfig.lua
+++ b/CardConfig.lua
@@ -1,0 +1,1575 @@
+ConfigCards = {}
+
+ConfigCards.Cards = {
+    {
+        name = "Flora Of North America",
+        number = "Card #8",
+        hash = 's_inv_cigcard_PLT_08x',
+        picked = false,
+        coords = {
+            ["x"] = -5617.5947,
+            ["y"] = -2946.2869,
+            ["z"] = 5.5759,
+            ["h"] = 71.3074
+        }
+    },
+    {
+        name = "Flora Of North America",
+        number = "Card #12",
+        hash = 's_inv_cigcard_PLT_12x',
+        coords = {
+            ["x"] = -5529.8599,
+            ["y"] = -2950.0166,
+            ["z"] = 3.2736,
+            ["h"] = 309.1028
+        }
+    },
+    {
+        name = "Stars Of The Stage",
+        number = "Card #3",
+        hash = 's_inv_cigcard_ACT_03x',
+        coords = {
+            ["x"] = -5511.8696,
+            ["y"] = -2880.1252,
+            ["z"] = -4.3058,
+            ["h"] = 101.5976
+        }
+    },
+    {
+        name = "Famous Gunslingers & Outlaws",
+        number = "Card #9",
+        hash = 's_inv_cigcard_GUN_09x',
+        coords = {
+            ["x"] = -5423.4888,
+            ["y"] = -2971.3831,
+            ["z"] = 13.0452,
+            ["h"] = 297.8644
+        }
+    },
+    {
+        name = "Vistas, Scenery & Cities Of America",
+        number = "Card #6",
+        hash = 's_inv_cigcard_LND_06x',
+        coords = {
+            ["x"] = -3551.8970,
+            ["y"] = -3010.4966,
+            ["z"] = 11.8220,
+            ["h"] = 6.0838
+        }
+    },
+    {
+        name = "Vistas, Scenery & Cities Of America",
+        number = "Card #4",
+        hash = 's_inv_cigcard_LND_04x',
+        coords = {
+            ["x"] = -3733.6714,
+            ["y"] = -2611.8369,
+            ["z"] = -12.8579,
+            ["h"] = 18.6332
+        }
+    },
+    {
+        name = "Famous Gunslingers & Outlaws",
+        number = "Card #7",
+        hash = 's_inv_cigcard_GUN_07x',
+        coords = {
+            ["x"] = -3643.9658,
+            ["y"] = -2624.4241,
+            ["z"] = -13.7338,
+            ["h"] = 84.0670
+        }
+    },
+    {
+        name = "Breeds Of Horses",
+        number = "Card #9",
+        hash = 's_inv_cigcard_HRS_09x',
+        coords = {
+            ["x"] = -3680.5881,
+            ["y"] = -2554.3044,
+            ["z"] = -13.5937,
+            ["h"] = 156.3389
+        }
+    },
+    {
+        name = "Stars Of The Stage",
+        number = "Card #8",
+        hash = 's_inv_cigcard_ACT_08x',
+        coords = {
+            ["x"] = -2493.3389,
+            ["y"] = -2432.2336,
+            ["z"] = 60.5997,
+            ["h"] = 287.3191
+        }
+    },
+    {
+        name = "Artists, Writers & Poets",
+        number = "Card #4",
+        hash = 's_inv_cigcard_ART_04x',
+        coords = {
+            ["x"] = -881.7477,
+            ["y"] = -1647.1343,
+            ["z"] = 69.5683,
+            ["h"] = 267.0215
+        }
+    },
+    {
+        name = "Fairest Flowers & Gems Of Beauty",
+        number = "Card #6",
+        hash = 's_inv_cigcard_GRL_06x',
+        coords = {
+            ["x"] = -825.4061,
+            ["y"] = -1348.4664,
+            ["z"] = 43.6294,
+            ["h"] = 251.4839
+        }
+    },
+    {
+        name = "Amazing Inventions",
+        number = "Card #4",
+        hash = 's_inv_cigcard_INV_04x',
+        coords = {
+            ["x"] = -955.9500,
+            ["y"] = -1318.1989,
+            ["z"] = 50.6010,
+            ["h"] = 182.2130
+        }
+    },
+    {
+        name = "Vistas, Scenery & Cities Of America",
+        number = "Card #3",
+        hash = 's_inv_cigcard_LND_03x',
+        coords = {
+            ["x"] = -834.0394,
+            ["y"] = -1286.5319,
+            ["z"] = 53.5716,
+            ["h"] = 266.2390
+        }
+    },
+    {
+        name = "Artists, Writers & Poets",
+        number = "Card #6",
+        hash = 's_inv_cigcard_ART_06x',
+        coords = {
+            ["x"] = -980.8656,
+            ["y"] = -1258.8082,
+            ["z"] = 52.6850,
+            ["h"] = 287.2771
+        }
+    },
+    {
+        name = "Famous Gunslingers & Outlaws",
+        number = "Card #8",
+        hash = 's_inv_cigcard_GUN_08x',
+        coords = {
+            ["x"] = -725.2998,
+            ["y"] = -1257.3153,
+            ["z"] = 44.7341,
+            ["h"] = 42.3911
+        }
+    },
+    {
+        name = "Marvels Of Travel  & Locomotion",
+        number = "Card #10",
+        hash = 's_inv_cigcard_VEH_10x',
+        coords = {
+            ["x"] = -1096.1108,
+            ["y"] = -578.9144,
+            ["z"] = 82.4161,
+            ["h"] = 311.6227
+        }
+    },
+    {
+        name = "Flora Of North America",
+        number = "Card #9",
+        hash = 's_inv_cigcard_PLT_09x',
+        coords = {
+            ["x"] = -1764.2583,
+            ["y"] = -435.9760,
+            ["z"] = 155.2233,
+            ["h"] = 86.2563
+        }
+    },
+    {
+        name = "Artists, Writers & Poets",
+        number = "Card #2",
+        hash = 's_inv_cigcard_ART_02x',
+        coords = {
+            ["x"] = -1819.4686,
+            ["y"] = -371.7454,
+            ["z"] = 166.4969,
+            ["h"] = 280.0540
+        }
+    },
+    {
+        name = "Marvels Of Travel  & Locomotion",
+        number = "Card #4",
+        hash = 's_inv_cigcard_VEH_04x',
+        coords = {
+            ["x"] = -1767.1846,
+            ["y"] = -370.2509,
+            ["z"] = 163.1306,
+            ["h"] = 284.8007
+        }
+    },
+    {
+        name = "Flora Of North America",
+        number = "Card #11",
+        hash = 's_inv_cigcard_PLT_11x',
+        coords = {
+            ["x"] = -2370.3586,
+            ["y"] = 476.8453,
+            ["z"] = 132.2230,
+            ["h"] = 9.5768
+        }
+    },
+    {
+        name = "Fauna Of North America",
+        number = "Card #1",
+        hash = 's_inv_cigcard_AML_01x',
+        coords = {
+            ["x"] = -2369.2200,
+            ["y"] = 474.2694,
+            ["z"] = 132.2289,
+            ["h"] = 262.1273
+        }
+    },
+    {
+        name = "Famous Gunslingers & Outlaws",
+        number = "Card #12",
+        hash = 's_inv_cigcard_GUN_12x',
+        coords = {
+            ["x"] = -2176.1069,
+            ["y"] = 715.2440,
+            ["z"] = 122.6525,
+            ["h"] = 316.7252
+        }
+    },
+    {
+        name = "Amazing Inventions",
+        number = "Card #3",
+        hash = 's_inv_cigcard_INV_03x',
+        coords = {
+            ["x"] = -2181.6340,
+            ["y"] = 721.0859,
+            ["z"] = 126.2033,
+            ["h"] = 109.4352
+        },
+        second_coords = {
+            ["x"] = -2177.3757,
+            ["y"] = 722.8018,
+            ["z"] = 126.2010,
+            ["h"] = 39.4322
+        }
+    },
+    {
+        name = "Stars Of The Stage",
+        number = "Card #4",
+        hash = 's_inv_cigcard_ACT_04x',
+        coords = {
+            ["x"] = -2237.7307,
+            ["y"] = 732.5734,
+            ["z"] = 136.3089,
+            ["h"] = 39.4988
+        }
+    },
+    {
+        name = "Fairest Flowers & Gems Of Beauty",
+        number = "Card #7",
+        hash = 's_inv_cigcard_GRL_07x',
+        coords = {
+            ["x"] = -2217.0073,
+            ["y"] = 726.6647,
+            ["z"] = 127.7005,
+            ["h"] = 105.9322
+        }
+    },
+    {
+        name = "Breeds Of Horses",
+        number = "Card #6",
+        hash = 's_inv_cigcard_HRS_06x',
+        coords = {
+            ["x"] = -1298.6433,
+            ["y"] = 408.5544,
+            ["z"] = 95.3838,
+            ["h"] = 73.7123
+        }
+    },
+    {
+        name = "Fairest Flowers & Gems Of Beauty",
+        number = "Card #8",
+        hash = 's_inv_cigcard_GRL_08x',
+        coords = {
+            ["x"] = -1384.5903,
+            ["y"] = 1153.8748,
+            ["z"] = 225.0466,
+            ["h"] = 325.3493
+        }
+    },
+    {
+        name = "The World's Champions",
+        number = "Cards #10",
+        hash = 's_inv_cigcard_SPT_10x',
+        coords = {
+            ["x"] = -1020.0111,
+            ["y"] = 1693.1990,
+            ["z"] = 244.3096,
+            ["h"] = 164.3407
+        }
+    },
+    {
+        name = "Famous Gunslingers & Outlaws",
+        number = "Card #3",
+        hash = 's_inv_cigcard_GUN_03x',
+        coords = {
+            ["x"] = -424.0702,
+            ["y"] = 1733.3652,
+            ["z"] = 216.5554,
+            ["h"] = 212.2417
+        }
+    },
+    {
+        name = "The World's Champions",
+        number = "Cards #2",
+        hash = 's_inv_cigcard_SPT_02x',
+        coords = {
+            ["x"] = -686.6374,
+            ["y"] = 1042.2949,
+            ["z"] = 135.0029,
+            ["h"] = 212.9959
+        }
+    },
+    {
+        name = "The World's Champions",
+        number = "Cards #11",
+        hash = 's_inv_cigcard_SPT_11x',
+        coords = {
+            ["x"] = -686.6374,
+            ["y"] = 1042.2949,
+            ["z"] = 135.0029,
+            ["h"] = 212.9959
+        }
+    },
+    {
+        name = "Breeds Of Horses",
+        number = "Card #7",
+        hash = 's_inv_cigcard_HRS_07x',
+        coords = {
+            ["x"] = -820.9626,
+            ["y"] = 354.5072,
+            ["z"] = 98.0781,
+            ["h"] = 88.0779
+        }
+    },
+    {
+        name = "Breeds Of Horses",
+        number = "Card #10",
+        hash = 's_inv_cigcard_HRS_10x',
+        coords = {
+            ["x"] = -865.0118,
+            ["y"] = 333.8043,
+            ["z"] = 99.8027,
+            ["h"] = 178.1974
+        }
+    },
+    {
+        name = "Breeds Of Horses",
+        number = "Card #3",
+        hash = 's_inv_cigcard_HRS_03x',
+        coords = {
+            ["x"] = -626.6384,
+            ["y"] = -73.5814,
+            ["z"] = 82.8523,
+            ["h"] = 185.6028
+        }
+    },
+    {
+        name = "Artists, Writers & Poets",
+        number = "Card #10",
+        hash = 's_inv_cigcard_ART_10x',
+        coords = {
+            ["x"] = -383.1024,
+            ["y"] = 919.4769,
+            ["z"] = 118.5316,
+            ["h"] = 4.2449
+        }
+    },
+    {
+        name = "Famous Gunslingers & Outlaws",
+        number = "Card #1",
+        hash = 's_inv_cigcard_GUN_01x',
+        coords = {
+            ["x"] = -231.9508,
+            ["y"] = 818.2557,
+            ["z"] = 124.3055,
+            ["h"] = 330.4124
+        }
+    },
+    {
+        name = "Amazing Inventions",
+        number = "Card #9",
+        hash = 's_inv_cigcard_INV_09x',
+        coords = {
+            ["x"] = -315.3461,
+            ["y"] = 812.0549,
+            ["z"] = 121.9762,
+            ["h"] = 90.5022
+        }
+    },
+    {
+        name = "Stars Of The Stage",
+        number = "Card #7",
+        hash = 's_inv_cigcard_ACT_07x',
+        coords = {
+            ["x"] = -380.5824,
+            ["y"] = 727.6285,
+            ["z"] = 116.0200,
+            ["h"] = 278.3780
+        }
+    },
+    {
+        name = "Stars Of The Stage",
+        number = "Card #9",
+        hash = 's_inv_cigcard_ACT_09x',
+        coords = {
+            ["x"] = -348.9319,
+            ["y"] = 694.9716,
+            ["z"] = 117.5002,
+            ["h"] = 99.5284
+        }
+    },
+    {
+        name = "Prominent Americans",
+        number = "Card #4",
+        hash = 'S_INV_CIGCARD_AMER_04X',
+        coords = {
+            ["x"] = -405.5653,
+            ["y"] = 663.2993,
+            ["z"] = 115.5527,
+            ["h"] = 105.5914
+        }
+    },
+    {
+        name = "Fairest Flowers & Gems Of Beauty",
+        number = "Card #11",
+        hash = 's_inv_cigcard_GRL_11x',
+        coords = {
+            ["x"] = -253.7329,
+            ["y"] = 638.8944,
+            ["z"] = 118.7465,
+            ["h"] = 315.8098
+        }
+    },
+    {
+        name = "Vistas, Scenery & Cities Of America",
+        number = "Card #9",
+        hash = 's_inv_cigcard_LND_09x',
+        coords = {
+            ["x"] = -181.3269,
+            ["y"] = 632.4587,
+            ["z"] = 114.0897,
+            ["h"] = 63.5415
+        }
+    },
+    {
+        name = "Famous Gunslingers & Outlaws",
+        number = "Card #2",
+        hash = 's_inv_cigcard_GUN_02x',
+        coords = {
+            ["x"] = -16.2848,
+            ["y"] = 1233.1180,
+            ["z"] = 173.2769,
+            ["h"] = 195.3443
+        }
+    },
+    {
+        name = "Fairest Flowers & Gems Of Beauty",
+        number = "Card #12",
+        hash = 's_inv_cigcard_GRL_12x',
+        coords = {
+            ["x"] = 572.7988,
+            ["y"] = 1689.1989,
+            ["z"] = 187.6315,
+            ["h"] = 311.6724
+        }
+    },
+    {
+        name = "Fauna Of North America",
+        number = "Card #11",
+        hash = 's_inv_cigcard_AML_11x',
+        coords = {
+            ["x"] = 218.3478,
+            ["y"] = 984.6891,
+            ["z"] = 190.9001,
+            ["h"] = 177.1216
+        }
+    },
+    {
+        name = "Vistas, Scenery & Cities Of America",
+        number = "Card #8",
+        hash = 's_inv_cigcard_LND_08x',
+        coords = {
+            ["x"] = -331.4270,
+            ["y"] = -366.1998,
+            ["z"] = 88.0785,
+            ["h"] = 61.5072
+        }
+    },
+    {
+        name = "Vistas, Scenery & Cities Of America",
+        number = "Card #5",
+        hash = 's_inv_cigcard_LND_05x',
+        coords = {
+            ["x"] = -322.8627,
+            ["y"] = -329.7148,
+            ["z"] = 102.4421,
+            ["h"] = 208.5022
+        }
+    },
+    {
+        name = "Fauna Of North America",
+        number = "Card #7",
+        hash = 's_inv_cigcard_AML_07x',
+        coords = {
+            ["x"] = 344.0609,
+            ["y"] = -664.2799,
+            ["z"] = 42.8224,
+            ["h"] = 162.5068
+        }
+    },
+    {
+        name = "The World's Champions",
+        number = "Cards #8",
+        hash = 's_inv_cigcard_SPT_08x',
+        coords = {
+            ["x"] = 499.2095,
+            ["y"] = 627.2585,
+            ["z"] = 111.7047,
+            ["h"] = 221.9539
+        }
+    },
+    {
+        name = "Fairest Flowers & Gems Of Beauty",
+        number = "Card #5",
+        hash = 's_inv_cigcard_GRL_05x',
+        coords = {
+            ["x"] = 500.5150,
+            ["y"] = 627.1988,
+            ["z"] = 111.7047,
+            ["h"] = 169.2799
+        }
+    },
+    {
+        name = "Prominent Americans",
+        number = "Card #9",
+        hash = 'S_INV_CIGCARD_AMER_09X',
+        coords = {
+            ["x"] = 594.8870,
+            ["y"] = 708.9436,
+            ["z"] = 118.5272,
+            ["h"] = 210.7803
+        }
+    },
+    {
+        name = "Famous Gunslingers & Outlaws",
+        number = "Card #6",
+        hash = 's_inv_cigcard_GUN_06x',
+        coords = {
+            ["x"] = 1587.7961,
+            ["y"] = 2193.5977,
+            ["z"] = 324.3895,
+            ["h"] = 119.8174
+        }
+    },
+    {
+        name = "Breeds Of Horses",
+        number = "Card #8",
+        hash = 's_inv_cigcard_HRS_08x',
+        coords = {
+            ["x"] = 1711.2173,
+            ["y"] = 1514.6246,
+            ["z"] = 147.5255,
+            ["h"] = 305.0735
+        }
+    },
+    {
+        name = "Artists, Writers & Poets",
+        number = "Card #3",
+        hash = 's_inv_cigcard_ART_03x',
+        coords = {
+            ["x"] = 1458.5281,
+            ["y"] = 814.0430,
+            ["z"] = 101.1335,
+            ["h"] = 85.2524
+        }
+    },
+    {
+        name = "Artists, Writers & Poets",
+        number = "Card #11",
+        hash = 's_inv_cigcard_ART_11x',
+        coords = {
+            ["x"] = 1115.1459,
+            ["y"] = 485.7841,
+            ["z"] = 97.2841,
+            ["h"] = 217.5477
+        }
+    },
+    {
+        name = "Stars Of The Stage",
+        number = "Card #11",
+        hash = 's_inv_cigcard_ACT_11x',
+        coords = {
+            ["x"] = 903.7382,
+            ["y"] = 260.9341,
+            ["z"] = 116.0042,
+            ["h"] = 92.5094
+        }
+    },
+    {
+        name = "Amazing Inventions",
+        number = "Card #11",
+        hash = 's_inv_cigcard_INV_11x',
+        coords = {
+            ["x"] = 2524.2480,
+            ["y"] = 2286.0449,
+            ["z"] = 177.3516,
+            ["h"] = 259.6279
+        }
+    },
+    {
+        name = "Fairest Flowers & Gems Of Beauty",
+        number = "Card #2",
+        hash = 's_inv_cigcard_GRL_02x',
+        coords = {
+            ["x"] = 2452.4849,
+            ["y"] = 2096.5459,
+            ["z"] = 173.3784,
+            ["h"] = 197.9841
+        }
+    },
+    {
+        name = "Fairest Flowers & Gems Of Beauty",
+        number = "Card #3",
+        hash = 's_inv_cigcard_GRL_03x',
+        coords = {
+            ["x"] = 2476.3252,
+            ["y"] = 1999.4919,
+            ["z"] = 168.2529,
+            ["h"] = 326.3024
+        }
+    },
+    {
+        name = "Marvels Of Travel  & Locomotion",
+        number = "Card #1",
+        hash = 's_inv_cigcard_VEH_01x',
+        coords = {
+            ["x"] = 3015.4927,
+            ["y"] = 1335.8304,
+            ["z"] = 42.7178,
+            ["h"] = 66.2471
+        }
+    },
+    {
+        name = "Amazing Inventions",
+        number = "Card #5",
+        hash = 's_inv_cigcard_INV_05x',
+        coords = {
+            ["x"] = 2955.6340,
+            ["y"] = 1318.1116,
+            ["z"] = 44.7540,
+            ["h"] = 340.9717
+        }
+    },
+    {
+        name = "Artists, Writers & Poets",
+        number = "Card #5",
+        hash = 's_inv_cigcard_ART_05x',
+        coords = {
+            ["x"] = 2920.3789,
+            ["y"] = 1379.0333,
+            ["z"] = 56.2246,
+            ["h"] = 82.7695
+        }
+    },
+    {
+        name = "The World's Champions",
+        number = "Cards #9",
+        hash = 's_inv_cigcard_SPT_09x',
+        coords = {
+            ["x"] = 2878.7476,
+            ["y"] = 1387.3314,
+            ["z"] = 84.0140,
+            ["h"] = 73.4884
+        }
+    },
+    {
+        name = "Vistas, Scenery & Cities Of America",
+        number = "Card #12",
+        hash = 's_inv_cigcard_LND_12x',
+        coords = {
+            ["x"] = 2846.2705,
+            ["y"] = 1374.1913,
+            ["z"] = 68.7967,
+            ["h"] = 309.5634
+        }
+    },
+    {
+        name = "Fairest Flowers & Gems Of Beauty",
+        number = "Card #4",
+        hash = 's_inv_cigcard_GRL_04x',
+        coords = {
+            ["x"] = 2751.9517,
+            ["y"] = 1320.4403,
+            ["z"] = 69.9881,
+            ["h"] = 97.1750
+        }
+    },
+    {
+        name = "Flora Of North America",
+        number = "Card #7",
+        hash = 's_inv_cigcard_PLT_07x',
+        coords = {
+            ["x"] = 2722.0339,
+            ["y"] = 1309.4908,
+            ["z"] = 73.7420,
+            ["h"] = 193.3129
+        }
+    },
+    {
+        name = "Famous Gunslingers & Outlaws",
+        number = "Card #4",
+        hash = 's_inv_cigcard_GUN_04x',
+        coords = {
+            ["x"] = 2556.7188,
+            ["y"] = 758.1410,
+            ["z"] = 76.8717,
+            ["h"] = 305.7002
+        }
+    },
+    {
+        name = "The World's Champions",
+        number = "Cards #1",
+        hash = 's_inv_cigcard_SPT_01x',
+        coords = {
+            ["x"] = 2540.9097,
+            ["y"] = 697.4770,
+            ["z"] = 80.7458,
+            ["h"] = 106.0835
+        }
+    },
+    {
+        name = "Flora Of North America",
+        number = "Card #2",
+        hash = 's_inv_cigcard_PLT_02x',
+        coords = {
+            ["x"] = 2718.3381,
+            ["y"] = 710.4100,
+            ["z"] = 79.5452,
+            ["h"] = 262.0057
+        }
+    },
+    {
+        name = "Fauna Of North America",
+        number = "Card #3",
+        hash = 's_inv_cigcard_AML_03x',
+        coords = {
+            ["x"] = 2008.6644,
+            ["y"] = 621.0639,
+            ["z"] = 158.6559,
+            ["h"] = 296.7993
+        }
+    },
+    {
+        name = "Fauna Of North America",
+        number = "Card #10",
+        hash = 's_inv_cigcard_AML_10x',
+        coords = {
+            ["x"] = 2018.2457,
+            ["y"] = 603.1783,
+            ["z"] = 161.1201,
+            ["h"] = 45.2325
+        }
+    },
+    {
+        name = "Flora Of North America",
+        number = "Card #6",
+        hash = 's_inv_cigcard_PLT_06x',
+        coords = {
+            ["x"] = 1522.9819,
+            ["y"] = 449.6942,
+            ["z"] = 90.3621,
+            ["h"] = 352.3291
+        }
+    },
+    {
+        name = "The World's Champions",
+        number = "Cards #3",
+        hash = 's_inv_cigcard_SPT_03x',
+        coords = {
+            ["x"] = 1445.4869,
+            ["y"] = 374.5126,
+            ["z"] = 89.8868,
+            ["h"] = 96.1212
+        }
+    },
+    {
+        name = "Marvels Of Travel  & Locomotion",
+        number = "Card #5",
+        hash = 's_inv_cigcard_VEH_05x',
+        coords = {
+            ["x"] = 1373.4812,
+            ["y"] = 356.8734,
+            ["z"] = 87.8144,
+            ["h"] = 10.6732
+        }
+    },
+    {
+        name = "Vistas, Scenery & Cities Of America",
+        number = "Card #10",
+        hash = 's_inv_cigcard_LND_10x',
+        coords = {
+            ["x"] = 1453.2408,
+            ["y"] = 288.5294,
+            ["z"] = 104.5148,
+            ["h"] = 137.0717
+        }
+    },
+    {
+        name = "The World's Champions",
+        number = "Cards #6",
+        hash = 's_inv_cigcard_SPT_06x',
+        coords = {
+            ["x"] = 1186.9805,
+            ["y"] = -102.7468,
+            ["z"] = 94.4628,
+            ["h"] = 183.5056
+        }
+    },
+    {
+        name = "Stars Of The Stage",
+        number = "Card #10",
+        hash = 's_inv_cigcard_ACT_10x',
+        coords = {
+            ["x"] = 1257.0928,
+            ["y"] = -408.3182,
+            ["z"] = 97.5992,
+            ["h"] = 91.0017
+        }
+    },
+    {
+        name = "Prominent Americans",
+        number = "Card #11",
+        hash = 'S_INV_CIGCARD_AMER_11X',
+        coords = {
+            ["x"] = 1625.3075,
+            ["y"] = -364.0681,
+            ["z"] = 75.8971,
+            ["h"] = 354.3536
+        }
+    },
+    {
+        name = "Prominent Americans",
+        number = "Card #3",
+        hash = 'S_INV_CIGCARD_AMER_03X',
+        coords = {
+            ["x"] = 1708.1871,
+            ["y"] = -385.0041,
+            ["z"] = 49.7815,
+            ["h"] = 106.0795
+        }
+    },
+    {
+        name = "Amazing Inventions",
+        number = "Card #12",
+        hash = 's_inv_cigcard_INV_12x',
+        coords = {
+            ["x"] = 1775.1053,
+            ["y"] = -470.4645,
+            ["z"] = 45.5979,
+            ["h"] = 125.3863
+        }
+    },
+    {
+        name = "Marvels Of Travel  & Locomotion",
+        number = "Card #11",
+        hash = 's_inv_cigcard_VEH_11x',
+        coords = {
+            ["x"] = 756.4330,
+            ["y"] = -975.4936,
+            ["z"] = 48.7142,
+            ["h"] = 207.8506
+        }
+    },
+    {
+        name = "Prominent Americans",
+        number = "Card #1",
+        hash = 'S_INV_CIGCARD_AMER_01X',
+        coords = {
+            ["x"] = 1052.3210,
+            ["y"] = -1120.3456,
+            ["z"] = 67.8829,
+            ["h"] = 22.4343
+        }
+    },
+    {
+        name = "Stars Of The Stage",
+        number = "Card #1",
+        hash = 's_inv_cigcard_ACT_01x',
+        coords = {
+            ["x"] = 1138.7965,
+            ["y"] = -979.7531,
+            ["z"] = 69.3926,
+            ["h"] = 275.7306
+        }
+    },
+    {
+        name = "Prominent Americans",
+        number = "Card #10",
+        hash = 'S_INV_CIGCARD_AMER_10X',
+        coords = {
+            ["x"] = 1391.5024,
+            ["y"] = -836.9624,
+            ["z"] = 68.3656,
+            ["h"] = 30.5322
+        }
+    },
+    {
+        name = "Stars Of The Stage",
+        number = "Card #12",
+        hash = 's_inv_cigcard_ACT_12x',
+        coords = {
+            ["x"] = 1305.5599,
+            ["y"] = -1138.5294,
+            ["z"] = 81.2444,
+            ["h"] = 35.0670
+        }
+    },
+    {
+        name = "Marvels Of Travel  & Locomotion",
+        number = "Card #7",
+        hash = 's_inv_cigcard_VEH_07x',
+        coords = {
+            ["x"] = 900.9095,
+            ["y"] = -1792.9851,
+            ["z"] = 43.0802,
+            ["h"] = 122.6814
+        }
+    },
+    {
+        name = "Artists, Writers & Poets",
+        number = "Card #1",
+        hash = 's_inv_cigcard_ART_01x',
+        coords = {
+            ["x"] = 1053.0137,
+            ["y"] = -1827.0981,
+            ["z"] = 48.4397,
+            ["h"] = 271.1135
+        }
+    },
+    {
+        name = "Breeds Of Horses",
+        number = "Card #12",
+        hash = 's_inv_cigcard_HRS_12x',
+        coords = {
+            ["x"] = 1319.3031,
+            ["y"] = -2287.4866,
+            ["z"] = 50.5363,
+            ["h"] = 298.2101
+        }
+    },
+    {
+        name = "Breeds Of Horses",
+        number = "Card #4",
+        hash = 's_inv_cigcard_HRS_04x',
+        coords = {
+            ["x"] = 1315.0315,
+            ["y"] = -2277.4333,
+            ["z"] = 50.5396,
+            ["h"] = 59.1056
+        }
+    },
+    {
+        name = "Breeds Of Horses",
+        number = "Card #11",
+        hash = 's_inv_cigcard_HRS_11x',
+        coords = {
+            ["x"] = 1212.4487,
+            ["y"] = -1275.3651,
+            ["z"] = 77.9136,
+            ["h"] = 203.8628
+        }
+    },
+    {
+        name = "Vistas, Scenery & Cities Of America",
+        number = "Card #11",
+        hash = 's_inv_cigcard_LND_11x',
+        coords = {
+            ["x"] = 1302.0393,
+            ["y"] = -1208.6930,
+            ["z"] = 81.2819,
+            ["h"] = 347.8859
+        }
+    },
+    {
+        name = "Famous Gunslingers & Outlaws",
+        number = "Card #5",
+        hash = 's_inv_cigcard_GUN_05x',
+        coords = {
+            ["x"] = 1296.0873,
+            ["y"] = -1273.0426,
+            ["z"] = 76.1071,
+            ["h"] = 167.1708
+        }
+    },
+    {
+        name = "Breeds Of Horses",
+        number = "Card #1",
+        hash = 's_inv_cigcard_HRS_01x',
+        coords = {
+            ["x"] = 1409.7869,
+            ["y"] = -1286.7872,
+            ["z"] = 78.2428,
+            ["h"] = 162.6940
+        }
+    },
+    {
+        name = "Marvels Of Travel  & Locomotion",
+        number = "Card #3",
+        hash = 's_inv_cigcard_VEH_03x',
+        coords = {
+            ["x"] = 1347.5294,
+            ["y"] = -1332.5034,
+            ["z"] = 77.5165,
+            ["h"] = 332.2873
+        }
+    },
+    {
+        name = "Breeds Of Horses",
+        number = "Card #5",
+        hash = 's_inv_cigcard_HRS_05x',
+        coords = {
+            ["x"] = 1311.2131,
+            ["y"] = -1354.3545,
+            ["z"] = 78.0342,
+            ["h"] = 68.6863
+        }
+    },
+    {
+        name = "Prominent Americans",
+        number = "Card #5",
+        hash = 'S_INV_CIGCARD_AMER_05X',
+        coords = {
+            ["x"] = 1415.0455,
+            ["y"] = -1400.0951,
+            ["z"] = 82.1481,
+            ["h"] = 335.6142
+        }
+    },
+    {
+        name = "Fauna Of North America",
+        number = "Card #2",
+        hash = 's_inv_cigcard_AML_02x',
+        coords = {
+            ["x"] = 1465.1240,
+            ["y"] = -1725.7509,
+            ["z"] = 62.2767,
+            ["h"] = 139.8916
+        }
+    },
+    {
+        name = "Amazing Inventions",
+        number = "Card #1",
+        hash = 's_inv_cigcard_INV_01x',
+        coords = {
+            ["x"] = 1585.6456,
+            ["y"] = -1845.1353,
+            ["z"] = 58.6760,
+            ["h"] = 85.9274
+        }
+    },
+    {
+        name = "Amazing Inventions",
+        number = "Card #8",
+        hash = 's_inv_cigcard_INV_08x',
+        coords = {
+            ["x"] = 1903.2570,
+            ["y"] = -1860.6189,
+            ["z"] = 47.3746,
+            ["h"] = 162.7829
+        }
+    },
+    {
+        name = "Prominent Americans",
+        number = "Card #12",
+        hash = 'S_INV_CIGCARD_AMER_12X',
+        coords = {
+            ["x"] = 2090.5178,
+            ["y"] = -1816.0092,
+            ["z"] = 42.9285,
+            ["h"] = 131.7143
+        }
+    },
+    {
+        name = "Vistas, Scenery & Cities Of America",
+        number = "Card #1",
+        hash = 's_inv_cigcard_LND_01x',
+        coords = {
+            ["x"] = 1833.4846,
+            ["y"] = -1422.6627,
+            ["z"] = 43.8362,
+            ["h"] = 198.9058
+        }
+    },
+    {
+        name = "Amazing Inventions",
+        number = "Card #7",
+        hash = 's_inv_cigcard_INV_07x',
+        coords = {
+            ["x"] = 1880.9674,
+            ["y"] = -1343.1703,
+            ["z"] = 42.5087,
+            ["h"] = 116.5913
+        }
+    },
+
+    {
+        name = "Prominent Americans",
+        number = "Card #6",
+        hash = 'S_INV_CIGCARD_AMER_06X',
+        coords = {
+            ["x"] = 2274.8926,
+            ["y"] = -1523.3413,
+            ["z"] = 43.6289,
+            ["h"] = 58.7145
+        }
+    },
+    {
+        name = "Prominent Americans",
+        number = "Card #7",
+        hash = 'S_INV_CIGCARD_AMER_07X',
+        coords = {
+            ["x"] = 2360.5107,
+            ["y"] = -1450.2856,
+            ["z"] = 46.0762,
+            ["h"] = 3.5418
+        }
+    },
+    {
+        name = "Breeds Of Horses",
+        number = "Card #2",
+        hash = 's_inv_cigcard_HRS_02x',
+        coords = {
+            ["x"] = 2549.9788,
+            ["y"] = -1574.2726,
+            ["z"] = 45.9694,
+            ["h"] = 101.7570
+        }
+    },
+    {
+        name = "Marvels Of Travel  & Locomotion",
+        number = "Card #8",
+        hash = 's_inv_cigcard_VEH_08x',
+        coords = {
+            ["x"] = 2679.5872,
+            ["y"] = -1563.7129,
+            ["z"] = 45.9697,
+            ["h"] = 269.5652
+        }
+    },
+    {
+        name = "Marvels Of Travel  & Locomotion",
+        number = "Card #9",
+        hash = 's_inv_cigcard_VEH_09x',
+        coords = {
+            ["x"] = 2832.4539,
+            ["y"] = -1414.7710,
+            ["z"] = 45.3944,
+            ["h"] = 253.9964
+        }
+    },
+    {
+        name = "Vistas, Scenery & Cities Of America",
+        number = "Card #2",
+        hash = 's_inv_cigcard_LND_02x',
+        coords = {
+            ["x"] = 2753.8804,
+            ["y"] = -1395.8075,
+            ["z"] = 46.2080,
+            ["h"] = 133.8637
+        }
+    },
+    {
+        name = "Artists, Writers & Poets",
+        number = "Card #8",
+        hash = 's_inv_cigcard_ART_08x',
+        coords = {
+            ["x"] = 2846.3513,
+            ["y"] = -1244.9381,
+            ["z"] = 47.6545,
+            ["h"] = 168.8695
+        }
+    },
+    {
+        name = "Fairest Flowers & Gems Of Beauty",
+        number = "Card #10",
+        hash = 's_inv_cigcard_GRL_10x',
+        coords = {
+            ["x"] = 2734.8169,
+            ["y"] = -1221.7931,
+            ["z"] = 49.6560,
+            ["h"] = 171.6369
+        }
+    },
+    {
+        name = "Marvels Of Travel  & Locomotion",
+        number = "Card #6",
+        hash = 's_inv_cigcard_VEH_06x',
+        coords = {
+            ["x"] = 2797.4292,
+            ["y"] = -1160.9403,
+            ["z"] = 47.9281,
+            ["h"] = 341.0346
+        }
+    },
+    {
+        name = "Flora Of North America",
+        number = "Card #3",
+        hash = 's_inv_cigcard_PLT_03x',
+        coords = {
+            ["x"] = 2731.1619,
+            ["y"] = -1189.1556,
+            ["z"] = 49.6752,
+            ["h"] = 28.6260
+        }
+    },
+    {
+        name = "Stars Of The Stage",
+        number = "Card #5",
+        hash = 's_inv_cigcard_ACT_05x',
+        coords = {
+            ["x"] = 2562.7605,
+            ["y"] = -1317.1334,
+            ["z"] = 49.2144,
+            ["h"] = 284.1105
+        }
+    },
+    {
+        name = "Stars Of The Stage",
+        number = "Card #6",
+        hash = 's_inv_cigcard_ACT_06x',
+        coords = {
+            ["x"] = 2563.7698,
+            ["y"] = -1317.6105,
+            ["z"] = 49.2130,
+            ["h"] = 10.5518
+        }
+    },
+    {
+        name = "The World's Champions",
+        number = "Cards #12",
+        hash = 's_inv_cigcard_SPT_12x',
+        coords = {
+            ["x"] = 2636.7188,
+            ["y"] = -1246.9192,
+            ["z"] = 53.3296,
+            ["h"] = 46.9084
+        }
+    },
+    {
+        name = "Amazing Inventions",
+        number = "Card #10",
+        hash = 's_inv_cigcard_INV_10x',
+        coords = {
+            ["x"] = 2634.9734,
+            ["y"] = -1240.6830,
+            ["z"] = 57.3241,
+            ["h"] = 261.7753
+        }
+    },
+    {
+        name = "Fauna Of North America",
+        number = "Card #4",
+        hash = 's_inv_cigcard_AML_04x',
+        coords = {
+            ["x"] = 2265.2207,
+            ["y"] = -1217.2723,
+            ["z"] = 42.2189,
+            ["h"] = 117.6261
+        }
+    },
+    {
+        name = "Marvels Of Travel  & Locomotion",
+        number = "Card #12",
+        hash = 's_inv_cigcard_VEH_12x',
+        coords = {
+            ["x"] = 2488.0071,
+            ["y"] = -1115.8104,
+            ["z"] = 50.3213,
+            ["h"] = 102.2604
+        }
+    },
+    {
+        name = "Amazing Inventions",
+        number = "Card #2",
+        hash = 's_inv_cigcard_INV_02x',
+        coords = {
+            ["x"] = 2724.9419,
+            ["y"] = -1124.3977,
+            ["z"] = 49.5590,
+            ["h"] = 267.2502
+        }
+    },
+    {
+        name = "The World's Champions",
+        number = "Cards #7",
+        hash = 's_inv_cigcard_SPT_07x',
+        coords = {
+            ["x"] = 2808.5271,
+            ["y"] = -1065.0966,
+            ["z"] = 46.4904,
+            ["h"] = 122.5257
+        }
+    },
+    {
+        name = "Famous Gunslingers & Outlaws",
+        number = "Card #11",
+        hash = 's_inv_cigcard_GUN_11x',
+        coords = {
+            ["x"] = 2711.8223,
+            ["y"] = -1053.9874,
+            ["z"] = 46.8905,
+            ["h"] = 95.3199
+        }
+    },
+    {
+        name = "Artists, Writers & Poets",
+        number = "Card #12",
+        hash = 's_inv_cigcard_ART_12x',
+        coords = {
+            ["x"] = 2597.7920,
+            ["y"] = -1031.1896,
+            ["z"] = 45.6760,
+            ["h"] = 95.2317
+        }
+    },
+    {
+        name = "Prominent Americans",
+        number = "Card #8",
+        hash = 'S_INV_CIGCARD_AMER_08X',
+        coords = {
+            ["x"] = 2636.3364,
+            ["y"] = -925.6525,
+            ["z"] = 43.0660,
+            ["h"] = 29.3505
+        }
+    },
+    {
+        name = "Flora Of North America",
+        number = "Card #4",
+        hash = 's_inv_cigcard_PLT_04x',
+        coords = {
+            ["x"] = 2369.3906,
+            ["y"] = -859.6332,
+            ["z"] = 43.0619,
+            ["h"] = 24.4944
+        }
+    },
+    {
+        name = "Flora Of North America",
+        number = "Card #5",
+        hash = 's_inv_cigcard_PLT_05x',
+        coords = {
+            ["x"] = 2374.0281,
+            ["y"] = -858.4252,
+            ["z"] = 41.9319,
+            ["h"] = 96.4897
+        }
+    },
+    {
+        name = "Fauna Of North America",
+        number = "Card #5",
+        hash = 's_inv_cigcard_AML_05x',
+        coords = {
+            ["x"] = 2258.7205,
+            ["y"] = -797.8845,
+            ["z"] = 44.1172,
+            ["h"] = 275.4631
+        }
+    },
+    {
+        name = "Flora Of North America",
+        number = "Card #1",
+        hash = 's_inv_cigcard_PLT_01x',
+        coords = {
+            ["x"] = 2238.9089,
+            ["y"] = -768.6769,
+            ["z"] = 43.4078,
+            ["h"] = 77.0264
+        }
+    },
+    {
+        name = "Fauna Of North America",
+        number = "Card #9",
+        hash = 's_inv_cigcard_AML_09x',
+        coords = {
+            ["x"] = 1874.0229,
+            ["y"] = -775.7093,
+            ["z"] = 42.4603,
+            ["h"] = 234.4033
+        }
+    },
+    {
+        name = "Prominent Americans",
+        number = "Card #2",
+        hash = 'S_INV_CIGCARD_AMER_02X',
+        coords = {
+            ["x"] = 2132.3665,
+            ["y"] = -640.2084,
+            ["z"] = 42.6086,
+            ["h"] = 88.0256
+        }
+    },
+    {
+        name = "Fauna Of North America",
+        number = "Card #6",
+        hash = 's_inv_cigcard_AML_06x',
+        coords = {
+            ["x"] = 2101.3425,
+            ["y"] = -612.4117,
+            ["z"] = 41.8782,
+            ["h"] = 193.2108
+        }
+    },
+    {
+        name = "The World's Champions",
+        number = "Cards #4",
+        hash = 's_inv_cigcard_SPT_04x',
+        coords = {
+            ["x"] = 2496.8208,
+            ["y"] = -421.2423,
+            ["z"] = 44.3727,
+            ["h"] = 218.3143
+        }
+    },
+    {
+        name = "Famous Gunslingers & Outlaws",
+        number = "Card #10",
+        hash = 's_inv_cigcard_GUN_10x',
+        coords = {
+            ["x"] = 2489.8003,
+            ["y"] = -419.7399,
+            ["z"] = 44.2337,
+            ["h"] = 78.1500
+        }
+    },
+    {
+        name = "Artists, Writers & Poets",
+        number = "Card #9",
+        hash = 's_inv_cigcard_ART_09x',
+        coords = {
+            ["x"] = 2329.6184,
+            ["y"] = -317.5721,
+            ["z"] = 41.6188,
+            ["h"] = 22.6035
+        }
+    },
+    {
+        name = "The World's Champions",
+        number = "Cards #5",
+        hash = 's_inv_cigcard_SPT_05x',
+        picked = false,
+        coords = {
+            ["x"] = 2235.7454,
+            ["y"] = -142.1148,
+            ["z"] = 47.6204,
+            ["h"] = 109.3891
+        }
+    },
+    {
+        name = "Fauna Of North America",
+        number = "Card #8",
+        hash = 's_inv_cigcard_AML_08x',
+        coords = {
+            ["x"] = 2446.5818,
+            ["y"] = 290.0824,
+            ["z"] = 67.2038,
+            ["h"] = 5.0017
+        }
+    },
+    {
+        name = "Vistas, Scenery & Cities Of America",
+        number = "Card #7",
+        hash = 's_inv_cigcard_LND_07x',
+        coords = {
+            ["x"] = 2441.1904,
+            ["y"] = 306.1721,
+            ["z"] = 74.7072,
+            ["h"] = 75.9826
+        }
+    },
+    {
+        name = "Artists, Writers & Poets",
+        number = "Card #7",
+        hash = 's_inv_cigcard_ART_07x',
+        coords = {
+            ["x"] = 2824.3479,
+            ["y"] = 280.4843,
+            ["z"] = 51.0772,
+            ["h"] = 317.8869
+        }
+    },
+    {
+        name = "Marvels Of Travel  & Locomotion",
+        number = "Card #2",
+        hash = 's_inv_cigcard_VEH_02x',
+        coords = {
+            ["x"] = 2990.7339,
+            ["y"] = 472.4872,
+            ["z"] = 42.0025,
+            ["h"] = 22.3546
+        }
+    },
+    {
+        name = "Fauna Of North America",
+        number = "Card #12",
+        hash = 's_inv_cigcard_AML_12x',
+        coords = {
+            ["x"] = 2972.1536,
+            ["y"] = 494.4659,
+            ["z"] = 48.4034,
+            ["h"] = 98.8146
+        }
+    },
+    {
+        name = "Fairest Flowers & Gems Of Beauty",
+        number = "Card #9",
+        hash = 's_inv_cigcard_GRL_09x',
+        coords = {
+            ["x"] = 2946.3726,
+            ["y"] = 583.4391,
+            ["z"] = 44.4635,
+            ["h"] = 331.4875
+        }
+    },
+    {
+        name = "Amazing Inventions",
+        number = "Card #6",
+        hash = 's_inv_cigcard_INV_06x',
+        coords = {
+            ["x"] = 2899.7842,
+            ["y"] = 623.6471,
+            ["z"] = 57.7236,
+            ["h"] = 93.6164
+        }
+    },
+    {
+        name = "Stars Of The Stage",
+        number = "Card #2",
+        hash = 's_inv_cigcard_ACT_02x',
+        coords = {
+            ["x"] = 2780.2122,
+            ["y"] = 530.0074,
+            ["z"] = 68.3704,
+            ["h"] = 191.3829
+        }
+    }
+}

--- a/CardConfig.lua
+++ b/CardConfig.lua
@@ -1,7 +1,7 @@
 ConfigCards = {}
 ConfigCards.Item = "CollectorCard"
-Config.EnableCards = true
-Config.CardTime = 3600 -- = 1 hour, this is time in seconds before card can be collected again, you can also do 60 * 60 for example
+ConfigCards.Enable = true
+ConfigCards.CardTime = 3600 -- = 1 hour, this is time in seconds before card can be collected again, you can also do 60 * 60 for example
 ConfigCards.Cards = {
     {
         name = "Flora Of North America",

--- a/client/cards.lua
+++ b/client/cards.lua
@@ -8,7 +8,7 @@ CreateThread(function()
         Wait(5)
         local coords, cardcoords = GetEntityCoords(PlayerPedId()), nil
         for k, v in pairs(ConfigCards.Cards) do
-            if GetDistanceBetweenCoords(coords, v.coords.x, v.coords.y, v.coords.z, true) < 5 then
+            if GetDistanceBetweenCoords(coords, v.coords.x, v.coords.y, v.coords.z, true) < 15 then
                 if not cardmade then
                     propEntity = CreateObject(GetHashKey(v.hash), v.coords.x, v.coords.y, v.coords.z, false, true, false,
                         false, true)
@@ -17,7 +17,7 @@ CreateThread(function()
                     FreezeEntityPosition(propEntity, true)
                 end
                 cardcoords = GetEntityCoords(propEntity)
-                if GetDistanceBetweenCoords(coords, cardcoords, false) < 4.5 then
+                if GetDistanceBetweenCoords(coords, cardcoords, false) < 2.0 then
                     PromptGroup:ShowGroup(Config.Language.Pickup)
                     if firstprompt:HasCompleted() then
                         TriggerServerEvent('bcc-nazar:CardCooldownSV', v)

--- a/client/cards.lua
+++ b/client/cards.lua
@@ -38,6 +38,11 @@ if ConfigCards.Enabled then
                         DeleteEntity(propEntity)
                         v.spawned = false
                     end
+                   if cardmade then
+                       if IsControlJustPressed(0, 0x308588E6) then
+                           ClearPedTasks(PlayerPedId())
+                       end
+                   end
                 end
             end
         end
@@ -49,6 +54,7 @@ RegisterNetEvent('bcc-nazar:UseCard', function(hash)
     Citizen.InvokeNative(0xCB9401F918CB0F75, PlayerPedId(), "GENERIC_DOCUMENT_FLIP_AVAILABLE", true, -1)
     TaskItemInteraction_2(PlayerPedId(), GetHashKey(hash), propEntity, GetHashKey('PrimaryItem'),
         GetHashKey('CIGARETTE_CARD_W6-5_H10-7_SINGLE_INTRO'), 1, 0, -1.0)
+                  cardmade = true
 end)
 
 RegisterNetEvent('bcc-nazar:ClientCardCheck', function(check)

--- a/client/cards.lua
+++ b/client/cards.lua
@@ -1,3 +1,5 @@
+local cardmade, CardCheck = false, false
+
 CreateThread(function()
     local PromptGroup = VORPutils.Prompts:SetupPromptGroup()
     local firstprompt = PromptGroup:RegisterPrompt(Config.Language.Pickup, 0x760A9C6F, 1, 1, true, 'hold',
@@ -5,10 +7,9 @@ CreateThread(function()
     while true do
         Wait(5)
         local coords, cardcoords = GetEntityCoords(PlayerPedId()), nil
-        for k, v in pairs(Config.Cards) do
+        for k, v in pairs(ConfigCards.Cards) do
             if GetDistanceBetweenCoords(coords, v.coords.x, v.coords.y, v.coords.z, true) < 5 then
                 if not cardmade then
-                    print('spawning card')
                     propEntity = CreateObject(GetHashKey(v.hash), v.coords.x, v.coords.y, v.coords.z, false, true, false,
                         false, true)
                     Citizen.InvokeNative(0x9587913B9E772D29, propEntity, true)
@@ -17,19 +18,18 @@ CreateThread(function()
                 end
                 cardcoords = GetEntityCoords(propEntity)
                 if GetDistanceBetweenCoords(coords, cardcoords, false) < 4.5 then
-                    print('near card')
                     PromptGroup:ShowGroup(Config.Language.Pickup)
                     if firstprompt:HasCompleted() then
-                        TriggerServerEvent('nate_commands:CardCooldownSV', v)
+                        TriggerServerEvent('bcc-nazar:CardCooldownSV', v)
                         Wait(250)
                         if not CardCheck then
                             TaskPlayAnim(PlayerPedId(), "mech_inspection@cigarette_card@ground", "enter", 5.0, 5.0, 3500,
                                 01, 0)
-                            VORPcore.NotifyLeft("Card Collected", "You've collected a card", "INVENTORY_ITEMS",
+                            VORPcore.NotifyLeft("Config,Language.CardCollected", "Config,Language.CardCollected", "INVENTORY_ITEMS",
                                 "document_cig_card_act", 4000, "Color_white")
-                            TriggerServerEvent('nate_commands:GetCard', v.name .. ' ' .. v.number, v.hash)
+                            TriggerServerEvent('bcc-nazar:GetCard', v.name .. ' ' .. v.number, v.hash)
                         else
-                            VORPcore.NotifyRightTip("You can not collect this card again", 4000)
+                            VORPcore.NotifyRightTip("Config,Language.CantCollectCard", 4000)
                         end
                     end
                 end
@@ -41,7 +41,7 @@ CreateThread(function()
     end
 end)
 
-RegisterNetEvent('nate_commands:UseCard', function(hash)
+RegisterNetEvent('bcc-nazar:UseCard', function(hash)
     local coords = GetEntityCoords(PlayerPedId())
     local propEntity = CreateObject(GetHashKey(hash), coords, false, true, false, false, true)
     Citizen.InvokeNative(0xCB9401F918CB0F75, PlayerPedId(), "GENERIC_DOCUMENT_FLIP_AVAILABLE", true, -1)
@@ -49,6 +49,6 @@ RegisterNetEvent('nate_commands:UseCard', function(hash)
         GetHashKey('CIGARETTE_CARD_W6-5_H10-7_SINGLE_INTRO'), 1, 0, -1.0)
 end)
 
-RegisterNetEvent('nate_commands:ClientCardCheck', function(check)
+RegisterNetEvent('bcc-nazar:ClientCardCheck', function(check)
     CardCheck = check
 end)

--- a/client/cards.lua
+++ b/client/cards.lua
@@ -1,0 +1,54 @@
+CreateThread(function()
+    local PromptGroup = VORPutils.Prompts:SetupPromptGroup()
+    local firstprompt = PromptGroup:RegisterPrompt(Config.Language.Pickup, 0x760A9C6F, 1, 1, true, 'hold',
+        { timedeventhash = "MEDIUM_TIMED_EVENT" })
+    while true do
+        Wait(5)
+        local coords, cardcoords = GetEntityCoords(PlayerPedId()), nil
+        for k, v in pairs(Config.Cards) do
+            if GetDistanceBetweenCoords(coords, v.coords.x, v.coords.y, v.coords.z, true) < 5 then
+                if not cardmade then
+                    print('spawning card')
+                    propEntity = CreateObject(GetHashKey(v.hash), v.coords.x, v.coords.y, v.coords.z, false, true, false,
+                        false, true)
+                    Citizen.InvokeNative(0x9587913B9E772D29, propEntity, true)
+                    cardmade = true
+                    FreezeEntityPosition(propEntity, true)
+                end
+                cardcoords = GetEntityCoords(propEntity)
+                if GetDistanceBetweenCoords(coords, cardcoords, false) < 4.5 then
+                    print('near card')
+                    PromptGroup:ShowGroup(Config.Language.Pickup)
+                    if firstprompt:HasCompleted() then
+                        TriggerServerEvent('nate_commands:CardCooldownSV', v)
+                        Wait(250)
+                        if not CardCheck then
+                            TaskPlayAnim(PlayerPedId(), "mech_inspection@cigarette_card@ground", "enter", 5.0, 5.0, 3500,
+                                01, 0)
+                            VORPcore.NotifyLeft("Card Collected", "You've collected a card", "INVENTORY_ITEMS",
+                                "document_cig_card_act", 4000, "Color_white")
+                            TriggerServerEvent('nate_commands:GetCard', v.name .. ' ' .. v.number, v.hash)
+                        else
+                            VORPcore.NotifyRightTip("You can not collect this card again", 4000)
+                        end
+                    end
+                end
+            else
+                cardmade = false
+                DeleteEntity(propEntity)
+            end
+        end
+    end
+end)
+
+RegisterNetEvent('nate_commands:UseCard', function(hash)
+    local coords = GetEntityCoords(PlayerPedId())
+    local propEntity = CreateObject(GetHashKey(hash), coords, false, true, false, false, true)
+    Citizen.InvokeNative(0xCB9401F918CB0F75, PlayerPedId(), "GENERIC_DOCUMENT_FLIP_AVAILABLE", true, -1)
+    TaskItemInteraction_2(PlayerPedId(), GetHashKey(hash), propEntity, GetHashKey('PrimaryItem'),
+        GetHashKey('CIGARETTE_CARD_W6-5_H10-7_SINGLE_INTRO'), 1, 0, -1.0)
+end)
+
+RegisterNetEvent('nate_commands:ClientCardCheck', function(check)
+    CardCheck = check
+end)

--- a/client/cards.lua
+++ b/client/cards.lua
@@ -1,7 +1,7 @@
 local cardmade, CardCheck = false, false
 
-if CardsConfig.Enabled then
-    CreateThread(function()
+if ConfigCards.Enabled then
+       CreateThread(function()
         local PromptGroup = VORPutils.Prompts:SetupPromptGroup()
         local firstprompt = PromptGroup:RegisterPrompt(Config.Language.Pickup, 0x760A9C6F, 1, 1, true, 'hold',
             { timedeventhash = "MEDIUM_TIMED_EVENT" })
@@ -11,7 +11,7 @@ if CardsConfig.Enabled then
         while true do
             Wait(5)
             local coords, cardcoords = GetEntityCoords(PlayerPedId()), nil
-            for k, v in pairs(Config.Cards) do
+            for k, v in pairs(ConfigCards.Cards) do
                 if GetDistanceBetweenCoords(coords, v.coords.x, v.coords.y, v.coords.z, true) < 15 then
                     if not v.spawned then
                         propEntity = CreateObject(GetHashKey(v.hash), v.coords.x, v.coords.y, v.coords.z, false, true, false,
@@ -27,13 +27,9 @@ if CardsConfig.Enabled then
                             TriggerServerEvent('bcc-nazar:CardCooldownSV', v)
                             Wait(250)
                             if not CardCheck then
-                                TaskPlayAnim(PlayerPedId(), "mech_inspection@cigarette_card@ground", "enter", 5.0, 5.0, 3500,
-                                    01, 0)
-                                VORPcore.NotifyLeft("Config.Language.CardCollected", "Config.Language.YouCollected", "INVENTORY_ITEMS",
-                                    "document_cig_card_act", 4000, "Color_white")
                                 TriggerServerEvent('bcc-nazar:GetCard', v.name .. ' ' .. v.number, v.hash)
                             else
-                                VORPcore.NotifyRightTip("Config.Language.CantCollectCard", 4000)
+                                VORPcore.NotifyRightTip(Config.Language.CantCollectCard, 4000)
                             end
                         end
                     end

--- a/client/cards.lua
+++ b/client/cards.lua
@@ -25,11 +25,11 @@ CreateThread(function()
                         if not CardCheck then
                             TaskPlayAnim(PlayerPedId(), "mech_inspection@cigarette_card@ground", "enter", 5.0, 5.0, 3500,
                                 01, 0)
-                            VORPcore.NotifyLeft("Config,Language.CardCollected", "Config,Language.CardCollected", "INVENTORY_ITEMS",
+                            VORPcore.NotifyLeft("Config.Language.CardCollected", "Config.Language.CardCollected", "INVENTORY_ITEMS",
                                 "document_cig_card_act", 4000, "Color_white")
                             TriggerServerEvent('bcc-nazar:GetCard', v.name .. ' ' .. v.number, v.hash)
                         else
-                            VORPcore.NotifyRightTip("Config,Language.CantCollectCard", 4000)
+                            VORPcore.NotifyRightTip("Config.Language.CantCollectCard", 4000)
                         end
                     end
                 end

--- a/config.lua
+++ b/config.lua
@@ -213,10 +213,6 @@ Config.TreasureLocations = {
     },
 }
 
------- Card Setup -----
-Config.CardsEnable = true --if true collectable cards will be enabled
-Config.CardRespawnTime = 30000 --how often in ms the cards will respawn
-
 --This is the shop configuration
 --You can add as many items to sale as you want just copy the line paste it and change it to your new item
 --itemdbname is the database name of the item and displayname is what will show in the menu with nazar

--- a/config.lua
+++ b/config.lua
@@ -216,20 +216,6 @@ Config.TreasureLocations = {
 ------ Card Setup -----
 Config.CardsEnable = true --if true collectable cards will be enabled
 Config.CardRespawnTime = 30000 --how often in ms the cards will respawn
-Config.CollectableCards = {
-    {
-        coords = {x = 1486.19, y = 791.14, z = 99.81}, --coords the card will spawn at
-        carditem = 'water', --item to give database name
-        carditemdisplayname = 'Water', --this is the name of the carditem that will show in the items recieved notification
-        cardname = 'Collector Card 1', --display name that will be shown in the prompt to pick card up (MAKE SURE THESE ARE UNIQUE NAMES OTHERWISE IT WILL BREAK)
-    },
-    {
-        coords = {x = 1489.69, y = 783.15, z = 99.74}, --coords the card will spawn at
-        carditem = 'iron', --item to give database name
-        carditemdisplayname = 'Iron', --this is the name of the carditem that will show in the items recieved notification
-        cardname = 'Collector Card 2', --display name that will be shown in the prompt to pick card up (MAKE SURE THESE ARE UNIQUE NAMES OTHERWISE IT WILL BREAK)
-    },
-}
 
 --This is the shop configuration
 --You can add as many items to sale as you want just copy the line paste it and change it to your new item
@@ -288,7 +274,10 @@ Config.Language = {
     NoGold = "You do not have enugh gold", -- added by mrtb
     NoChest = "Someone has already looted this chest!",
     Alreadylooted = "You looted the chest!",
-    ChestLooted = 'Items Recieved: '
+    ChestLooted = 'Items Recieved: ',
+    Pickup = "Pick up Card",
+    CardCollected = "Card Collected",
+    CantCollectCard = "This card has been grabbed by someone recently and you must wait"
 }
 
 --[[--------BLIP_COLORS----------

--- a/config.lua
+++ b/config.lua
@@ -271,10 +271,13 @@ Config.Language = {
     NoChest = "Someone has already looted this chest!",
     Alreadylooted = "You looted the chest!",
     ChestLooted = 'Items Recieved: ',
+    
     Pickup = "Pick up Card",
     YouCollected = "You have collected a card",
     CardCollected = "Card Collected",
-    CantCollectCard = "This card has been grabbed by someone recently and you must wait"
+    CantCollectCard = "This card has been grabbed by someone recently and you must wait",
+    StackFull = "You can't carry anymore of this item",
+    InvFull = "You can't carry anymore"
 }
 
 --[[--------BLIP_COLORS----------

--- a/config.lua
+++ b/config.lua
@@ -272,6 +272,7 @@ Config.Language = {
     Alreadylooted = "You looted the chest!",
     ChestLooted = 'Items Recieved: ',
     Pickup = "Pick up Card",
+    YouCollected = "You have collected a card",
     CardCollected = "Card Collected",
     CantCollectCard = "This card has been grabbed by someone recently and you must wait"
 }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -11,6 +11,7 @@ server_scripts {
 
 shared_scripts {
     'config.lua',
+    'CardConfig.lua'
 }
 
 
@@ -18,9 +19,10 @@ client_scripts {
     '/client/menusetup.lua',
     '/client/nazarspawn.lua',
     '/client/treasurehunt.lua',
+    '/client/cards.lua'
 }
 
-version '1.2.0'
+version '1.3.0'
 
 dependency {
     'vorp_core',


### PR DESCRIPTION
Thanks to the community for collecting the spots, getting the coords, Jake for the cooldown code, and Eltz for the spawn snippets I've started using, with all this, and some research, tweaking and more, I, and more importantly the BCC team presents! Nazar Collectibles!

This update adds the spawning of over 140 collectible cards into the world at all of the regular RDO locations, these can be changed in the CardConfig file, the cooldown is a server wide cooldown, giving that added fight and push to your players, its a first come first serve basis ladies and gentlemen, once someone collects that specific card, you must wait the cooldown.

All Cards save as the item you have and the metadata saves the cards unique information, ie the hash for spawning into your hand later, the Collectible pack it is from, and the number in the pack it is.

This gives those players who need something to look for an activity and can allow selling to a vendor to make some cash, maybe you even decide to create custom cards using the available RDO card images IE ByteSized the General using a Famous American Figures card

Tested and made to work with the newest and older VORP Inventories.
If you use a card while at a prompt, you should be able to esc to get rid of the card at least