### PR TITLE
Add Job Permissions + Fix UserLog Loading + Add Collector Card Config

### DIFF
--- a/config/config.lua
+++ b/config/config.lua
@@ -65,6 +65,14 @@ Config.nazar = {
 }
 -----------------------------------------------------
 
+Config.jobPermissions = {
+    enabled = false, -- Set to false to disable job restrictions for hints
+    allowedJobs = {
+        collector = { minGrade = 0, maxGrade = 5 }
+        -- Add more jobs as needed
+    }
+}
+-----------------------------------------------------
 Config.BlipColors = {
     LIGHT_BLUE    = 'BLIP_MODIFIER_MP_COLOR_1',
     DARK_RED      = 'BLIP_MODIFIER_MP_COLOR_2',

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -23,7 +23,7 @@ server_scripts {
     'server/versioncheck.lua'
 }
 
-version '1.6.0'
+version '1.7.0'
 
 dependency {
     'vorp_core',

--- a/languages/en_lang.lua
+++ b/languages/en_lang.lua
@@ -1,7 +1,7 @@
 ---------------------------------- ENGLISH -------------------------------------------
--- Please send Pull Request to GitHub with Language Updates
+
 Locales["en_lang"] = {
-    
+
     TreasureBlipName = 'Treasure?',
     TreasurePromptTitle = 'Search the chest for clues',
     TreasurePrompt_search = "Open",
@@ -77,5 +77,6 @@ Locales["en_lang"] = {
         'I see the ruins of a battle fought long ago.',
         'Remember, the stars favor those who leave no stone unturned.',
         'Take care... Your next drink will go to your head...'
-    }
+    },
+    jobNotAllowed = "You do not have the required job to purchase this hint."
 }

--- a/languages/fr_lang.lua
+++ b/languages/fr_lang.lua
@@ -77,5 +77,6 @@ Locales["fr_lang"] = {
         "I see the ruins of a battle fought long ago.",
         "Remember, the stars favor those who leave no stone unturned.",
         "Be careful... Your next drink will tip you over..."
-    }
+    },
+    jobNotAllowed = "You do not have the required job to purchase this hint."
 }

--- a/languages/it_lang.lua
+++ b/languages/it_lang.lua
@@ -77,5 +77,6 @@ Locales["it_lang"] = {
         "I see the ruins of a battle fought long ago.",
         "Remember, the stars favor those who leave no stone unturned.",
         "Be careful... Your next drink will tip you over..."
-    }
+    },
+    jobNotAllowed = "You do not have the required job to purchase this hint."
 }

--- a/languages/ro_lang.lua
+++ b/languages/ro_lang.lua
@@ -77,5 +77,6 @@ Locales["ro_lang"] = {
         "Vad ruinele unei batalii purtate demult.",
         "Aminteste-ti, stelele favorizeaza pe cei care nu lasa nicio piatra neintoarsa.",
         "Ai grija... Urmatoarea ta bautura te va da peste cap..."
-    }
+    },
+    jobNotAllowed = "Nu ai meseria necesara pentru a cumpara acest indiciu."
 }

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
-<1.6.0>
+<1.7.0>
 See GitHub for Details!


### PR DESCRIPTION
- Added job permission check for `bcc-nazar:BuyHint` with `Config.jobPermissions`.
- Jobs and grades are configurable, and the system can be enabled/disabled (`enabled = true/false`).
- Added localization for "job not allowed" in English, French, and Italian.
- Fixed `UserLogAPI` loading:
  - Moved `UserLogAPI = exports['bcc-userlog']:getUserLogAPI()` **inside** `if Config.useBccUserlog then` to avoid unnecessary export calls.
- Modified usable item `collector_card`:
  - Added missing config entry for `collector_card` in `ConfigCards`.